### PR TITLE
Add alicebot-dashboard MVP (Bun + Elysia + React)

### DIFF
--- a/alicebot-dashboard/README.md
+++ b/alicebot-dashboard/README.md
@@ -1,0 +1,51 @@
+# alicebot-dashboard
+
+Dashboard local para gerenciar o **alicebot.exe** com API HTTP + WebSocket em `http://127.0.0.1:3130`.
+
+## Como rodar
+
+```bash
+bun install
+bun dev
+```
+
+A aplicação ficará disponível em `http://127.0.0.1:3130`.
+
+## Variáveis de ambiente
+
+Crie um `.env` (opcional):
+
+```
+ADMIN_TOKEN=troque-este-token
+ALICEBOT_PATH=C:\Users\alice\.local\bin\alicebot.exe
+```
+
+- `ADMIN_TOKEN`: token esperado no header `X-Admin-Token` para rotas mutáveis.
+- `ALICEBOT_PATH`: path default do executável do bot (substituível pela UI).
+
+## Configurar path do executável
+
+- Abra a página **Settings**.
+- Ajuste **Bot executable path**.
+- Clique em **Test path** para validar.
+- Clique em **Save Settings** para persistir em `data/settings.json`.
+
+## Rotas da API
+
+- `GET /api/health`
+- `GET /api/status`
+- `GET /api/guilds`
+- `GET /api/services`
+- `GET /api/settings`
+- `PUT /api/settings` (X-Admin-Token)
+- `GET /api/logs?limit=200`
+- `POST /api/process/start` (X-Admin-Token)
+- `POST /api/process/stop` (X-Admin-Token)
+- `POST /api/process/restart` (X-Admin-Token)
+- `POST /api/process/validate-path` (X-Admin-Token)
+- `WS /api/stream`
+
+## Observações
+
+- Logs do processo são capturados de stdout/stderr, normalizados e distribuídos via WebSocket.
+- O stop do processo tenta `proc.kill()` e faz fallback para `taskkill` no Windows.

--- a/alicebot-dashboard/client/index.html
+++ b/alicebot-dashboard/client/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Alicebot Dashboard</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/static/main.js"></script>
+  </body>
+</html>

--- a/alicebot-dashboard/client/src/main.tsx
+++ b/alicebot-dashboard/client/src/main.tsx
@@ -1,0 +1,662 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "./styles.css";
+
+type LogLevel = "INFO" | "WARN" | "ERROR" | "DEBUG";
+
+type EventLog = {
+  ts: string;
+  level: LogLevel;
+  category: string;
+  message: string;
+  guildId?: string;
+  userId?: string;
+  channelId?: string;
+  meta?: Record<string, string>;
+  stream: "stdout" | "stderr";
+};
+
+type ProcessStatus = {
+  running: boolean;
+  pid?: number;
+  startedAt?: string;
+  lastExitCode?: number;
+  lastExitSignal?: string;
+  executablePath: string;
+};
+
+type GuildSettings = {
+  id: string;
+  name?: string;
+  enabled: boolean;
+  monitoringEnabled: boolean;
+  automodEnabled: boolean;
+  notificationChannelId?: string;
+};
+
+type Settings = {
+  executablePath: string;
+  guilds: GuildSettings[];
+  automodEnabled: boolean;
+  monitoringEnabled: boolean;
+};
+
+type ServiceStatus = { id: string; name: string; status: string };
+
+type ApiStatus = {
+  bot: { connected: boolean; username: string; guildCount: number; uptimeSeconds: number };
+  process: ProcessStatus;
+};
+
+const pages = [
+  "Overview",
+  "Guilds",
+  "Monitoring",
+  "Automod",
+  "Commands",
+  "Logs",
+  "Settings",
+] as const;
+
+type Page = (typeof pages)[number];
+
+const useAdminToken = () => {
+  const [token, setToken] = useState(() => localStorage.getItem("adminToken") ?? "");
+  useEffect(() => {
+    localStorage.setItem("adminToken", token);
+  }, [token]);
+  return [token, setToken] as const;
+};
+
+const fetchJson = async <T,>(input: RequestInfo, init?: RequestInit): Promise<T> => {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  return (await response.json()) as T;
+};
+
+const Card: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div className="card">
+    <div className="card-title">{title}</div>
+    <div className="card-body">{children}</div>
+  </div>
+);
+
+const Badge: React.FC<{ variant: "success" | "warning" | "danger" | "neutral"; label: string }> = ({
+  variant,
+  label,
+}) => <span className={`badge badge-${variant}`}>{label}</span>;
+
+const Toggle: React.FC<{ checked: boolean; onChange: (value: boolean) => void }> = ({
+  checked,
+  onChange,
+}) => (
+  <button className={`toggle ${checked ? "on" : "off"}`} onClick={() => onChange(!checked)}>
+    <span className="toggle-handle" />
+  </button>
+);
+
+const Table: React.FC<{ headers: string[]; children: React.ReactNode }> = ({ headers, children }) => (
+  <table className="table">
+    <thead>
+      <tr>
+        {headers.map((header) => (
+          <th key={header}>{header}</th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>{children}</tbody>
+  </table>
+);
+
+const Toast: React.FC<{ message: string; variant?: "success" | "error" }> = ({
+  message,
+  variant = "success",
+}) => <div className={`toast ${variant}`}>{message}</div>;
+
+const App = () => {
+  const [page, setPage] = useState<Page>("Overview");
+  const [status, setStatus] = useState<ApiStatus | null>(null);
+  const [services, setServices] = useState<ServiceStatus[]>([]);
+  const [settings, setSettings] = useState<Settings | null>(null);
+  const [logs, setLogs] = useState<EventLog[]>([]);
+  const [toast, setToast] = useState<{ message: string; variant?: "success" | "error" } | null>(null);
+  const [adminToken, setAdminToken] = useAdminToken();
+
+  const processStatus = status?.process;
+
+  const showToast = (message: string, variant: "success" | "error" = "success") => {
+    setToast({ message, variant });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const loadStatus = async () => {
+    try {
+      const data = await fetchJson<ApiStatus>("/api/status");
+      setStatus(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const loadSettings = async () => {
+    try {
+      const data = await fetchJson<Settings>("/api/settings");
+      setSettings(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const loadServices = async () => {
+    try {
+      const data = await fetchJson<ServiceStatus[]>("/api/services");
+      setServices(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const loadLogs = async () => {
+    try {
+      const data = await fetchJson<EventLog[]>("/api/logs?limit=200");
+      setLogs(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    void loadStatus();
+    void loadSettings();
+    void loadServices();
+    void loadLogs();
+    const interval = setInterval(loadStatus, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    let ws: WebSocket | null = null;
+    let timer: number | null = null;
+
+    const connect = () => {
+      ws = new WebSocket(`ws://${window.location.host}/api/stream`);
+      ws.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          if (payload.type === "log") {
+            setLogs((prev) => [...prev.slice(-199), payload.data]);
+          }
+          if (payload.type === "status") {
+            setStatus((prev) => (prev ? { ...prev, process: payload.data } : prev));
+          }
+        } catch {
+          // ignore
+        }
+      };
+      ws.onclose = () => {
+        timer = window.setTimeout(connect, 1500);
+      };
+    };
+
+    connect();
+
+    return () => {
+      ws?.close();
+      if (timer) window.clearTimeout(timer);
+    };
+  }, []);
+
+  const handleProcess = async (action: "start" | "stop" | "restart") => {
+    try {
+      const response = await fetchJson<ProcessStatus>(`/api/process/${action}`, {
+        method: "POST",
+        headers: { "X-Admin-Token": adminToken },
+      });
+      setStatus((prev) => (prev ? { ...prev, process: response } : prev));
+      showToast(`Process ${action} issued`);
+    } catch (error) {
+      showToast(String(error), "error");
+    }
+  };
+
+  const updateSettings = async (next: Settings) => {
+    try {
+      const response = await fetchJson<Settings>("/api/settings", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Admin-Token": adminToken,
+        },
+        body: JSON.stringify(next),
+      });
+      setSettings(response);
+      showToast("Settings saved");
+    } catch (error) {
+      showToast(String(error), "error");
+    }
+  };
+
+  const uptimeLabel = useMemo(() => {
+    if (!processStatus?.running || !processStatus.startedAt) return "--";
+    const started = new Date(processStatus.startedAt).getTime();
+    const diff = Date.now() - started;
+    const hours = Math.floor(diff / 3600000);
+    const minutes = Math.floor((diff % 3600000) / 60000);
+    const seconds = Math.floor((diff % 60000) / 1000);
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }, [processStatus]);
+
+  return (
+    <div className="app">
+      <aside className="sidebar">
+        <div className="brand">
+          <div className="brand-logo">A</div>
+          <div>
+            <div className="brand-title">alicebot</div>
+            <div className="brand-subtitle">dashboard</div>
+          </div>
+        </div>
+        <nav>
+          {pages.map((item) => (
+            <button
+              key={item}
+              className={`nav-item ${page === item ? "active" : ""}`}
+              onClick={() => setPage(item)}
+            >
+              {item}
+            </button>
+          ))}
+        </nav>
+      </aside>
+      <main className="main">
+        <header className="topbar">
+          <div className="topbar-left">
+            <Badge
+              variant={processStatus?.running ? "success" : "danger"}
+              label={processStatus?.running ? "Running" : "Stopped"}
+            />
+            <div className="uptime">Uptime: {uptimeLabel}</div>
+          </div>
+          <div className="topbar-actions">
+            <button className="btn" onClick={() => handleProcess("start")}>Start</button>
+            <button className="btn" onClick={() => handleProcess("stop")}>Stop</button>
+            <button className="btn btn-primary" onClick={() => handleProcess("restart")}>
+              Restart
+            </button>
+            <div className="discord-status">
+              <span>Connected to Discord</span>
+              <Badge variant={status?.bot.connected ? "success" : "warning"} label={status?.bot.connected ? "Online" : "Mock"} />
+            </div>
+          </div>
+        </header>
+
+        <section className="content">
+          {page === "Overview" && (
+            <OverviewPage
+              status={status}
+              services={services}
+              logs={logs}
+              onRefresh={loadStatus}
+            />
+          )}
+          {page === "Guilds" && settings && (
+            <GuildsPage settings={settings} onUpdate={updateSettings} />
+          )}
+          {page === "Monitoring" && settings && (
+            <MonitoringPage settings={settings} onUpdate={updateSettings} />
+          )}
+          {page === "Automod" && settings && (
+            <AutomodPage settings={settings} onUpdate={updateSettings} />
+          )}
+          {page === "Commands" && <CommandsPage />}
+          {page === "Logs" && <LogsPage logs={logs} />}
+          {page === "Settings" && settings && (
+            <SettingsPage
+              settings={settings}
+              onUpdate={updateSettings}
+              adminToken={adminToken}
+              setAdminToken={setAdminToken}
+            />
+          )}
+        </section>
+      </main>
+      {toast && <Toast message={toast.message} variant={toast.variant} />}
+    </div>
+  );
+};
+
+const OverviewPage: React.FC<{
+  status: ApiStatus | null;
+  services: ServiceStatus[];
+  logs: EventLog[];
+  onRefresh: () => void;
+}> = ({ status, services, logs, onRefresh }) => (
+  <div className="grid">
+    <Card title="Process Status">
+      <div className="stat">
+        <strong>Status:</strong> {status?.process.running ? "Running" : "Stopped"}
+      </div>
+      <div className="stat">
+        <strong>PID:</strong> {status?.process.pid ?? "--"}
+      </div>
+      <button className="btn" onClick={onRefresh}>
+        Refresh
+      </button>
+    </Card>
+    <Card title="Guilds">
+      <div className="stat">
+        <strong>Total:</strong> {status?.bot.guildCount ?? 0}
+      </div>
+    </Card>
+    <Card title="Services">
+      {services.map((service) => (
+        <div className="service" key={service.id}>
+          <span>{service.name}</span>
+          <Badge
+            variant={service.status === "healthy" ? "success" : "warning"}
+            label={service.status}
+          />
+        </div>
+      ))}
+    </Card>
+    <Card title="Recent Activity">
+      <div className="log-preview">
+        {logs.slice(-5).map((log, index) => (
+          <div key={`${log.ts}-${index}`} className="log-line">
+            [{log.level}] {log.message}
+          </div>
+        ))}
+      </div>
+    </Card>
+  </div>
+);
+
+const GuildsPage: React.FC<{ settings: Settings; onUpdate: (s: Settings) => void }> = ({
+  settings,
+  onUpdate,
+}) => (
+  <div>
+    <h2>Guilds</h2>
+    <Table headers={["Guild", "Enabled", "Monitoring", "Automod"]}>
+      {settings.guilds.map((guild) => (
+        <tr key={guild.id}>
+          <td>
+            <div className="guild-name">{guild.name ?? guild.id}</div>
+            <div className="muted">{guild.id}</div>
+          </td>
+          <td>
+            <Toggle
+              checked={guild.enabled}
+              onChange={(value) =>
+                onUpdate({
+                  ...settings,
+                  guilds: settings.guilds.map((item) =>
+                    item.id === guild.id ? { ...item, enabled: value } : item
+                  ),
+                })
+              }
+            />
+          </td>
+          <td>
+            <Toggle
+              checked={guild.monitoringEnabled}
+              onChange={(value) =>
+                onUpdate({
+                  ...settings,
+                  guilds: settings.guilds.map((item) =>
+                    item.id === guild.id ? { ...item, monitoringEnabled: value } : item
+                  ),
+                })
+              }
+            />
+          </td>
+          <td>
+            <Toggle
+              checked={guild.automodEnabled}
+              onChange={(value) =>
+                onUpdate({
+                  ...settings,
+                  guilds: settings.guilds.map((item) =>
+                    item.id === guild.id ? { ...item, automodEnabled: value } : item
+                  ),
+                })
+              }
+            />
+          </td>
+        </tr>
+      ))}
+    </Table>
+  </div>
+);
+
+const MonitoringPage: React.FC<{ settings: Settings; onUpdate: (s: Settings) => void }> = ({
+  settings,
+  onUpdate,
+}) => (
+  <div>
+    <h2>Monitoring</h2>
+    <div className="form-row">
+      <label>Monitoring Enabled</label>
+      <Toggle
+        checked={settings.monitoringEnabled}
+        onChange={(value) => onUpdate({ ...settings, monitoringEnabled: value })}
+      />
+    </div>
+    <Table headers={["Guild", "Monitoring", "Notification Channel"]}>
+      {settings.guilds.map((guild) => (
+        <tr key={guild.id}>
+          <td>{guild.name ?? guild.id}</td>
+          <td>
+            <Toggle
+              checked={guild.monitoringEnabled}
+              onChange={(value) =>
+                onUpdate({
+                  ...settings,
+                  guilds: settings.guilds.map((item) =>
+                    item.id === guild.id ? { ...item, monitoringEnabled: value } : item
+                  ),
+                })
+              }
+            />
+          </td>
+          <td>
+            <input
+              className="input"
+              value={guild.notificationChannelId ?? ""}
+              placeholder="Channel ID"
+              onChange={(event) =>
+                onUpdate({
+                  ...settings,
+                  guilds: settings.guilds.map((item) =>
+                    item.id === guild.id
+                      ? { ...item, notificationChannelId: event.target.value }
+                      : item
+                  ),
+                })
+              }
+            />
+          </td>
+        </tr>
+      ))}
+    </Table>
+  </div>
+);
+
+const AutomodPage: React.FC<{ settings: Settings; onUpdate: (s: Settings) => void }> = ({
+  settings,
+  onUpdate,
+}) => (
+  <div>
+    <h2>Automod</h2>
+    <div className="form-row">
+      <label>Automod Enabled</label>
+      <Toggle
+        checked={settings.automodEnabled}
+        onChange={(value) => onUpdate({ ...settings, automodEnabled: value })}
+      />
+    </div>
+    <Card title="Rules (placeholder)">
+      <ul>
+        <li>Anti-spam cooldown</li>
+        <li>Caps lock limiter</li>
+        <li>Invite link blocker</li>
+      </ul>
+    </Card>
+  </div>
+);
+
+const CommandsPage: React.FC = () => (
+  <div>
+    <h2>Commands</h2>
+    <Card title="Available Commands">
+      <ul className="command-list">
+        <li>/ping</li>
+        <li>/echo</li>
+        <li>/metrics</li>
+        <li>/moderation</li>
+        <li>/config</li>
+      </ul>
+    </Card>
+  </div>
+);
+
+const LogsPage: React.FC<{ logs: EventLog[] }> = ({ logs }) => {
+  const [levelFilter, setLevelFilter] = useState<LogLevel | "ALL">("ALL");
+  const [categoryFilter, setCategoryFilter] = useState<string>("");
+  const [search, setSearch] = useState<string>("");
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  const filtered = useMemo(() => {
+    return logs.filter((log) => {
+      if (levelFilter !== "ALL" && log.level !== levelFilter) return false;
+      if (categoryFilter && log.category !== categoryFilter) return false;
+      if (search && !log.message.toLowerCase().includes(search.toLowerCase())) return false;
+      return true;
+    });
+  }, [logs, levelFilter, categoryFilter, search]);
+
+  useEffect(() => {
+    if (autoScroll) {
+      const container = document.querySelector(".log-console");
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    }
+  }, [filtered, autoScroll]);
+
+  const categories = Array.from(new Set(logs.map((log) => log.category)));
+
+  return (
+    <div>
+      <h2>Logs</h2>
+      <div className="filters">
+        <select value={levelFilter} onChange={(event) => setLevelFilter(event.target.value as LogLevel | "ALL")}>
+          <option value="ALL">All levels</option>
+          <option value="INFO">INFO</option>
+          <option value="WARN">WARN</option>
+          <option value="ERROR">ERROR</option>
+          <option value="DEBUG">DEBUG</option>
+        </select>
+        <select value={categoryFilter} onChange={(event) => setCategoryFilter(event.target.value)}>
+          <option value="">All categories</option>
+          {categories.map((category) => (
+            <option key={category} value={category}>
+              {category}
+            </option>
+          ))}
+        </select>
+        <input
+          className="input"
+          placeholder="Search logs"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        <label className="inline-toggle">
+          <input type="checkbox" checked={autoScroll} onChange={(event) => setAutoScroll(event.target.checked)} />
+          Auto-scroll
+        </label>
+      </div>
+      <div className="log-console">
+        {filtered.length === 0 && <div className="empty">No logs yet.</div>}
+        {filtered.map((log, index) => (
+          <div key={`${log.ts}-${index}`} className={`log-line log-${log.level.toLowerCase()}`}>
+            <span className="log-ts">{new Date(log.ts).toLocaleTimeString()}</span>
+            <span className="log-level">[{log.level}]</span>
+            <span className="log-category">[{log.category}]</span>
+            <span className="log-message">{log.message}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const SettingsPage: React.FC<{
+  settings: Settings;
+  onUpdate: (s: Settings) => void;
+  adminToken: string;
+  setAdminToken: (value: string) => void;
+}> = ({ settings, onUpdate, adminToken, setAdminToken }) => {
+  const [path, setPath] = useState(settings.executablePath);
+  const [validation, setValidation] = useState<string>("");
+
+  const testPath = async () => {
+    try {
+      const response = await fetchJson<{ ok: boolean }>("/api/process/validate-path", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Admin-Token": adminToken,
+        },
+        body: JSON.stringify({ path }),
+      });
+      setValidation(response.ok ? "Path ok" : "Path not found");
+    } catch (error) {
+      setValidation(String(error));
+    }
+  };
+
+  return (
+    <div>
+      <h2>Settings</h2>
+      <div className="form-grid">
+        <label>Admin Token</label>
+        <input
+          className="input"
+          value={adminToken}
+          onChange={(event) => setAdminToken(event.target.value)}
+          placeholder="X-Admin-Token"
+        />
+        <label>Bot executable path</label>
+        <div className="inline">
+          <input
+            className="input"
+            value={path}
+            onChange={(event) => setPath(event.target.value)}
+            placeholder="C:\\Users\\alice\\.local\\bin\\alicebot.exe"
+          />
+          <button className="btn" onClick={testPath}>
+            Test path
+          </button>
+        </div>
+        <div className="hint">{validation}</div>
+      </div>
+      <button
+        className="btn btn-primary"
+        onClick={() => onUpdate({ ...settings, executablePath: path })}
+      >
+        Save Settings
+      </button>
+      <Card title="Settings JSON">
+        <pre className="json-view">{JSON.stringify(settings, null, 2)}</pre>
+      </Card>
+    </div>
+  );
+};
+
+const container = document.getElementById("root");
+if (container) {
+  createRoot(container).render(<App />);
+}

--- a/alicebot-dashboard/client/src/styles.css
+++ b/alicebot-dashboard/client/src/styles.css
@@ -1,0 +1,368 @@
+:root {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #e7eaf3;
+  background-color: #0f111a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0f111a;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 240px;
+  background: #151826;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-logo {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: #6c5ce7;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.brand-title {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.brand-subtitle {
+  font-size: 12px;
+  color: #98a0b3;
+}
+
+.nav-item {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: transparent;
+  color: #c9cede;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nav-item.active,
+.nav-item:hover {
+  background: #23283b;
+  color: #fff;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 28px;
+  background: #111422;
+  border-bottom: 1px solid #1e2233;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.uptime {
+  font-size: 13px;
+  color: #9aa4bd;
+}
+
+.discord-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: #1c2032;
+}
+
+.content {
+  padding: 24px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: #151a29;
+  border-radius: 16px;
+  padding: 18px;
+  border: 1px solid #1f2435;
+}
+
+.card-title {
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge-success {
+  background: rgba(46, 204, 113, 0.2);
+  color: #2ecc71;
+}
+
+.badge-warning {
+  background: rgba(241, 196, 15, 0.2);
+  color: #f1c40f;
+}
+
+.badge-danger {
+  background: rgba(231, 76, 60, 0.2);
+  color: #e74c3c;
+}
+
+.badge-neutral {
+  background: rgba(149, 165, 166, 0.2);
+  color: #95a5a6;
+}
+
+.btn {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid #2a3044;
+  background: #1a1f33;
+  color: #e7eaf3;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: #6c5ce7;
+  border-color: #6c5ce7;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 10px 8px;
+  border-bottom: 1px solid #22273a;
+}
+
+.toggle {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  border: none;
+  position: relative;
+  background: #2a3044;
+  cursor: pointer;
+}
+
+.toggle.on {
+  background: #6c5ce7;
+}
+
+.toggle-handle {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #fff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 0.2s ease;
+}
+
+.toggle.on .toggle-handle {
+  transform: translateX(20px);
+}
+
+.input,
+select {
+  background: #151a29;
+  border: 1px solid #2a3044;
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: #e7eaf3;
+}
+
+.form-row,
+.form-grid {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.form-grid {
+  grid-template-columns: 180px 1fr;
+  align-items: center;
+}
+
+.inline {
+  display: flex;
+  gap: 8px;
+}
+
+.inline-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.log-console {
+  background: #0c0f19;
+  border: 1px solid #1f2435;
+  padding: 12px;
+  border-radius: 12px;
+  max-height: 420px;
+  overflow: auto;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+}
+
+.log-line {
+  display: flex;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.log-info {
+  color: #9aa4bd;
+}
+
+.log-warn {
+  color: #f1c40f;
+}
+
+.log-error {
+  color: #e74c3c;
+}
+
+.log-debug {
+  color: #6c5ce7;
+}
+
+.log-ts {
+  color: #586080;
+}
+
+.filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  background: #1c2032;
+  border: 1px solid #2a3044;
+}
+
+.toast.success {
+  border-color: #2ecc71;
+}
+
+.toast.error {
+  border-color: #e74c3c;
+}
+
+.muted {
+  color: #9aa4bd;
+  font-size: 12px;
+}
+
+.log-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.command-list {
+  padding-left: 16px;
+}
+
+.json-view {
+  max-height: 240px;
+  overflow: auto;
+  background: #0c0f19;
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.service {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.empty {
+  color: #9aa4bd;
+  padding: 12px 0;
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    width: 200px;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/alicebot-dashboard/data/settings.json
+++ b/alicebot-dashboard/data/settings.json
@@ -1,0 +1,22 @@
+{
+  "executablePath": "C:\\Users\\alice\\.local\\bin\\alicebot.exe",
+  "guilds": [
+    {
+      "id": "123456789012345678",
+      "name": "Alice Community",
+      "enabled": true,
+      "monitoringEnabled": true,
+      "automodEnabled": true,
+      "notificationChannelId": "987654321098765432"
+    },
+    {
+      "id": "234567890123456789",
+      "name": "Dev Lounge",
+      "enabled": true,
+      "monitoringEnabled": false,
+      "automodEnabled": false
+    }
+  ],
+  "automodEnabled": true,
+  "monitoringEnabled": true
+}

--- a/alicebot-dashboard/package.json
+++ b/alicebot-dashboard/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "alicebot-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run build:client && bun run src/server.ts",
+    "build:client": "bun run scripts/build-client.ts",
+    "start": "bun run src/server.ts"
+  },
+  "dependencies": {
+    "@elysiajs/cors": "^1.0.2",
+    "elysia": "^1.0.16",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.5.3"
+  }
+}

--- a/alicebot-dashboard/scripts/build-client.ts
+++ b/alicebot-dashboard/scripts/build-client.ts
@@ -1,0 +1,25 @@
+import { mkdir, copyFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+const clientDir = join(root, "client");
+const distDir = join(clientDir, "dist");
+const staticDir = join(distDir, "static");
+
+await mkdir(staticDir, { recursive: true });
+
+const result = await Bun.build({
+  entrypoints: [join(clientDir, "src", "main.tsx")],
+  outdir: staticDir,
+  minify: true,
+  sourcemap: "external",
+  target: "browser",
+});
+
+if (!result.success) {
+  console.error(result.logs);
+  process.exit(1);
+}
+
+await copyFile(join(clientDir, "index.html"), join(distDir, "index.html"));
+await copyFile(join(clientDir, "src", "styles.css"), join(staticDir, "styles.css"));

--- a/alicebot-dashboard/src/adapter/alicebot.ts
+++ b/alicebot-dashboard/src/adapter/alicebot.ts
@@ -1,0 +1,176 @@
+import type { EventLog, ProcessStatus } from "../types";
+
+type LogSink = (log: EventLog) => void;
+
+type StatusSink = (status: ProcessStatus) => void;
+
+const parseLogLine = (line: string, stream: "stdout" | "stderr"): EventLog => {
+  const now = new Date().toISOString();
+  if (line.includes("time=") && line.includes("level=") && line.includes("msg=")) {
+    const tokens = Array.from(line.matchAll(/(\w+)=(("[^"]*")|(\S+))/g));
+    const map: Record<string, string> = {};
+    for (const token of tokens) {
+      const key = token[1];
+      const rawValue = token[2];
+      map[key] = rawValue.startsWith('"')
+        ? rawValue.slice(1, -1)
+        : rawValue;
+    }
+
+    const meta: Record<string, string> = {};
+    for (const [key, value] of Object.entries(map)) {
+      if (["time", "level", "category", "msg"].includes(key)) {
+        continue;
+      }
+      meta[key] = value;
+    }
+
+    return {
+      ts: map.time ?? now,
+      level: (map.level?.toUpperCase() ?? "INFO") as EventLog["level"],
+      category: map.category ?? "process",
+      message: map.msg ?? line,
+      guildId: map.guildID ?? map.guildId,
+      userId: map.userID ?? map.userId,
+      channelId: map.channelID ?? map.channelId,
+      meta: Object.keys(meta).length ? meta : undefined,
+      stream,
+    };
+  }
+
+  return {
+    ts: now,
+    level: "INFO",
+    category: "process",
+    message: line,
+    stream,
+  };
+};
+
+const streamLines = async (
+  stream: ReadableStream<Uint8Array> | null,
+  streamType: "stdout" | "stderr",
+  sink: LogSink
+) => {
+  if (!stream) return;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      if (buffer.trim().length) {
+        sink(parseLogLine(buffer.trim(), streamType));
+      }
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    let index = buffer.indexOf("\n");
+    while (index !== -1) {
+      const line = buffer.slice(0, index).trim();
+      if (line.length) {
+        sink(parseLogLine(line, streamType));
+      }
+      buffer = buffer.slice(index + 1);
+      index = buffer.indexOf("\n");
+    }
+  }
+};
+
+export class AliceBotAdapter {
+  private process: Bun.Subprocess | null = null;
+  private status: ProcessStatus;
+
+  constructor(
+    private getExecutablePath: () => string,
+    private logSink: LogSink,
+    private statusSink: StatusSink
+  ) {
+    this.status = {
+      running: false,
+      executablePath: this.getExecutablePath(),
+    };
+  }
+
+  getStatus(): ProcessStatus {
+    return { ...this.status, executablePath: this.getExecutablePath() };
+  }
+
+  async start(): Promise<ProcessStatus> {
+    if (this.process) {
+      return this.getStatus();
+    }
+
+    const executablePath = this.getExecutablePath();
+    const proc = Bun.spawn({
+      cmd: [executablePath],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    this.process = proc;
+    this.status = {
+      running: true,
+      pid: proc.pid,
+      startedAt: new Date().toISOString(),
+      executablePath,
+    };
+    this.statusSink(this.getStatus());
+
+    void streamLines(proc.stdout, "stdout", this.logSink);
+    void streamLines(proc.stderr, "stderr", this.logSink);
+
+    proc.exited.then(({ code, signal }) => {
+      this.process = null;
+      this.status = {
+        running: false,
+        startedAt: this.status.startedAt,
+        executablePath,
+        lastExitCode: code ?? undefined,
+        lastExitSignal: signal ?? undefined,
+      };
+      this.statusSink(this.getStatus());
+    });
+
+    return this.getStatus();
+  }
+
+  async stop(): Promise<ProcessStatus> {
+    if (!this.process) {
+      return this.getStatus();
+    }
+
+    const current = this.process;
+    try {
+      current.kill();
+    } catch {
+      // ignore
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    if (this.process) {
+      const pid = this.process.pid;
+      try {
+        if (process.platform === "win32" && pid) {
+          Bun.spawn({
+            cmd: ["cmd", "/c", "taskkill", "/PID", String(pid), "/T", "/F"],
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    await current.exited.catch(() => undefined);
+    return this.getStatus();
+  }
+
+  async restart(): Promise<ProcessStatus> {
+    await this.stop();
+    return this.start();
+  }
+}

--- a/alicebot-dashboard/src/logs.ts
+++ b/alicebot-dashboard/src/logs.ts
@@ -1,0 +1,27 @@
+import type { EventLog } from "./types";
+
+export class LogStore {
+  private logs: EventLog[] = [];
+  private listeners = new Set<(log: EventLog) => void>();
+
+  constructor(private maxSize = 5000) {}
+
+  add(log: EventLog) {
+    this.logs.push(log);
+    if (this.logs.length > this.maxSize) {
+      this.logs.splice(0, this.logs.length - this.maxSize);
+    }
+    for (const listener of this.listeners) {
+      listener(log);
+    }
+  }
+
+  list(limit = 200): EventLog[] {
+    return this.logs.slice(-limit);
+  }
+
+  onLog(listener: (log: EventLog) => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}

--- a/alicebot-dashboard/src/server.ts
+++ b/alicebot-dashboard/src/server.ts
@@ -1,0 +1,156 @@
+import { Elysia } from "elysia";
+import cors from "@elysiajs/cors";
+import { resolve } from "node:path";
+import { stat } from "node:fs/promises";
+import { AliceBotAdapter } from "./adapter/alicebot";
+import { LogStore } from "./logs";
+import { loadSettings, saveSettings, validateSettingsPayload } from "./settings";
+import type { BotStatus, ProcessStatus, Settings } from "./types";
+
+const appHost = "127.0.0.1";
+const appPort = 3130;
+const allowedOrigin = `http://${appHost}:${appPort}`;
+const adminToken = process.env.ADMIN_TOKEN ?? "change-me";
+
+const logs = new LogStore(5000);
+let settings = await loadSettings();
+
+const wsClients = new Set<any>();
+
+const broadcast = (payload: unknown) => {
+  const message = JSON.stringify(payload);
+  for (const client of wsClients) {
+    try {
+      client.send(message);
+    } catch {
+      // ignore
+    }
+  }
+};
+
+const botStatus: BotStatus = {
+  connected: false,
+  username: "alicebot",
+  guildCount: settings.guilds.length,
+  uptimeSeconds: 0,
+};
+
+const adapter = new AliceBotAdapter(
+  () => settings.executablePath,
+  (log) => {
+    logs.add(log);
+    broadcast({ type: "log", data: log });
+  },
+  (status) => {
+    broadcast({ type: "status", data: status });
+  }
+);
+
+const ensureAdmin = (request: Request): Response | null => {
+  const token = request.headers.get("X-Admin-Token");
+  if (!token || token !== adminToken) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  return null;
+};
+
+const getProcessStatus = (): ProcessStatus => adapter.getStatus();
+
+const indexFile = resolve("./client/dist/index.html");
+const staticDir = resolve("./client/dist/static");
+
+const app = new Elysia()
+  .use(
+    cors({
+      origin: allowedOrigin,
+      methods: ["GET", "POST", "PUT"],
+      allowedHeaders: ["Content-Type", "X-Admin-Token"],
+    })
+  )
+  .get("/api/health", () => ({ status: "ok" }))
+  .get("/api/status", () => ({
+    bot: {
+      ...botStatus,
+      guildCount: settings.guilds.length,
+    },
+    process: getProcessStatus(),
+  }))
+  .get("/api/guilds", () => settings.guilds)
+  .get("/api/services", () => [
+    { id: "monitoring", name: "Monitoring", status: "healthy" },
+    { id: "automod", name: "Automod", status: "degraded" },
+    { id: "commands", name: "Commands", status: "healthy" },
+  ])
+  .get("/api/settings", () => settings)
+  .put("/api/settings", async ({ request }) => {
+    const auth = ensureAdmin(request);
+    if (auth) return auth;
+
+    const payload = await request.json();
+    const validation = validateSettingsPayload(payload);
+    if (!validation.ok) {
+      return new Response(validation.error, { status: 400 });
+    }
+
+    settings = validation.settings;
+    await saveSettings(settings);
+    return settings;
+  })
+  .get("/api/logs", ({ query }) => {
+    const limit = Number(query.limit ?? "200");
+    return logs.list(Number.isNaN(limit) ? 200 : limit);
+  })
+  .post("/api/process/start", ({ request }) => {
+    const auth = ensureAdmin(request);
+    if (auth) return auth;
+    return adapter.start();
+  })
+  .post("/api/process/stop", ({ request }) => {
+    const auth = ensureAdmin(request);
+    if (auth) return auth;
+    return adapter.stop();
+  })
+  .post("/api/process/restart", ({ request }) => {
+    const auth = ensureAdmin(request);
+    if (auth) return auth;
+    return adapter.restart();
+  })
+  .post("/api/process/validate-path", async ({ request }) => {
+    const auth = ensureAdmin(request);
+    if (auth) return auth;
+    const body = (await request.json().catch(() => null)) as
+      | { path?: string }
+      | null;
+    const path = body?.path;
+    if (!path) {
+      return new Response("Path is required", { status: 400 });
+    }
+    try {
+      const info = await stat(path);
+      return { ok: info.isFile() };
+    } catch {
+      return { ok: false };
+    }
+  })
+  .ws("/api/stream", {
+    open(ws) {
+      wsClients.add(ws);
+      ws.send(JSON.stringify({ type: "status", data: getProcessStatus() }));
+    },
+    close(ws) {
+      wsClients.delete(ws);
+    },
+    message(ws, message) {
+      if (message === "ping") {
+        ws.send("pong");
+      }
+    },
+  })
+  .get("/static/*", ({ params }) => {
+    const file = Bun.file(resolve(staticDir, params["*"]));
+    return new Response(file);
+  })
+  .get("/*", () => new Response(Bun.file(indexFile)))
+  .listen({ hostname: appHost, port: appPort });
+
+console.log(`alicebot-dashboard listening on http://${appHost}:${appPort}`);

--- a/alicebot-dashboard/src/settings.ts
+++ b/alicebot-dashboard/src/settings.ts
@@ -1,0 +1,116 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import type { GuildSettings, Settings } from "./types";
+
+const defaultExecutablePath =
+  process.env.ALICEBOT_PATH ?? "C:\\Users\\alice\\.local\\bin\\alicebot.exe";
+
+export const settingsPath = resolve("./data/settings.json");
+
+const defaultGuilds: GuildSettings[] = [
+  {
+    id: "123456789012345678",
+    name: "Alice Community",
+    enabled: true,
+    monitoringEnabled: true,
+    automodEnabled: true,
+    notificationChannelId: "987654321098765432",
+  },
+  {
+    id: "234567890123456789",
+    name: "Dev Lounge",
+    enabled: true,
+    monitoringEnabled: false,
+    automodEnabled: false,
+  },
+];
+
+const defaultSettings: Settings = {
+  executablePath: defaultExecutablePath,
+  guilds: defaultGuilds,
+  automodEnabled: true,
+  monitoringEnabled: true,
+};
+
+const isGuildSettings = (value: GuildSettings): boolean => {
+  return (
+    typeof value.id === "string" &&
+    typeof value.enabled === "boolean" &&
+    typeof value.monitoringEnabled === "boolean" &&
+    typeof value.automodEnabled === "boolean"
+  );
+};
+
+const sanitizeGuilds = (guilds: unknown): GuildSettings[] => {
+  if (!Array.isArray(guilds)) {
+    return defaultGuilds;
+  }
+
+  return guilds
+    .map((guild) => {
+      if (typeof guild !== "object" || guild === null) {
+        return null;
+      }
+
+      const data = guild as Partial<GuildSettings>;
+      const sanitized: GuildSettings = {
+        id: data.id ?? "",
+        name: data.name,
+        enabled: Boolean(data.enabled),
+        monitoringEnabled: Boolean(data.monitoringEnabled),
+        automodEnabled: Boolean(data.automodEnabled),
+        notificationChannelId: data.notificationChannelId,
+      };
+
+      return sanitized;
+    })
+    .filter((guild): guild is GuildSettings => isGuildSettings(guild));
+};
+
+const sanitizeSettings = (input: Partial<Settings>): Settings => {
+  return {
+    executablePath: input.executablePath || defaultExecutablePath,
+    guilds: sanitizeGuilds(input.guilds),
+    automodEnabled:
+      typeof input.automodEnabled === "boolean"
+        ? input.automodEnabled
+        : defaultSettings.automodEnabled,
+    monitoringEnabled:
+      typeof input.monitoringEnabled === "boolean"
+        ? input.monitoringEnabled
+        : defaultSettings.monitoringEnabled,
+  };
+};
+
+export const loadSettings = async (): Promise<Settings> => {
+  try {
+    const raw = await readFile(settingsPath, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<Settings>;
+    return sanitizeSettings(parsed);
+  } catch {
+    await mkdir(dirname(settingsPath), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify(defaultSettings, null, 2));
+    return { ...defaultSettings };
+  }
+};
+
+export const saveSettings = async (settings: Settings): Promise<void> => {
+  const sanitized = sanitizeSettings(settings);
+  await mkdir(dirname(settingsPath), { recursive: true });
+  await writeFile(settingsPath, JSON.stringify(sanitized, null, 2));
+};
+
+export const validateSettingsPayload = (
+  payload: unknown
+): { ok: true; settings: Settings } | { ok: false; error: string } => {
+  if (typeof payload !== "object" || payload === null) {
+    return { ok: false, error: "Payload must be an object." };
+  }
+
+  const parsed = payload as Partial<Settings>;
+  if (!parsed.executablePath || typeof parsed.executablePath !== "string") {
+    return { ok: false, error: "executablePath must be a string." };
+  }
+
+  return { ok: true, settings: sanitizeSettings(parsed) };
+};

--- a/alicebot-dashboard/src/types.ts
+++ b/alicebot-dashboard/src/types.ts
@@ -1,0 +1,45 @@
+export type LogLevel = "INFO" | "WARN" | "ERROR" | "DEBUG";
+
+export type EventLog = {
+  ts: string;
+  level: LogLevel;
+  category: string;
+  message: string;
+  guildId?: string;
+  userId?: string;
+  channelId?: string;
+  meta?: Record<string, string>;
+  stream: "stdout" | "stderr";
+};
+
+export type ProcessStatus = {
+  running: boolean;
+  pid?: number;
+  startedAt?: string;
+  lastExitCode?: number;
+  lastExitSignal?: string;
+  executablePath: string;
+};
+
+export type BotStatus = {
+  connected: boolean;
+  username: string;
+  guildCount: number;
+  uptimeSeconds: number;
+};
+
+export type GuildSettings = {
+  id: string;
+  name?: string;
+  enabled: boolean;
+  monitoringEnabled: boolean;
+  automodEnabled: boolean;
+  notificationChannelId?: string;
+};
+
+export type Settings = {
+  executablePath: string;
+  guilds: GuildSettings[];
+  automodEnabled: boolean;
+  monitoringEnabled: boolean;
+};

--- a/alicebot-dashboard/tsconfig.json
+++ b/alicebot-dashboard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a local Bun-based dashboard to manage the `alicebot.exe` process with an integrated HTTP API and WebSocket stream at `http://127.0.0.1:3130`.
- Enable starting/stopping/restarting the Windows bot binary and stream live stdout/stderr logs to a web UI while persisting settings locally.

### Description

- Add a process adapter `src/adapter/alicebot.ts` implementing `start()`, `stop()`, `restart()`, `getStatus()` with Windows-friendly stop fallback to `taskkill`, plus a best-effort log parser that emits `EventLog` objects for stdout/stderr.
- Implement `LogStore` ring buffer and `settings` persistence in `src/settings.ts` with validation and `data/settings.json` defaults, and expose APIs in `src/server.ts` (Elysia) including `/api/status`, `/api/logs`, `/api/settings` (GET/PUT), process control endpoints and `POST /api/process/validate-path`, plus WebSocket `WS /api/stream` to broadcast logs and status.
- Add a full TypeScript React frontend in `client/src/main.tsx` and styling in `client/src/styles.css` with sidebar/topbar/pages (Overview, Guilds, Monitoring, Automod, Commands, Logs, Settings), WS client to `/api/stream`, and UI controls for process actions and settings editing.
- Provide project metadata and build scripts: `package.json`, `tsconfig.json`, `scripts/build-client.ts`, `client/index.html`, and `README.md` documenting run steps and env vars `ADMIN_TOKEN` / `ALICEBOT_PATH`.

### Testing

- Ran `bun install` to fetch dependencies and prepare the project, which failed due to npm registry access returning HTTP 403 in this environment, so the client build and `bun dev` were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696727ead5e88324bb7a7cdc366388a3)